### PR TITLE
Fix main page navigation by using Next.js Link components

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import type { WaitItem, TunnelId } from "@/types";
+import Link from "next/link";
 
 const STORAGE_KEY = "mtw.waits.v1";
 
@@ -58,7 +59,7 @@ export default function Home() {
   const Card = ({
     title, href, desc, emoji,
   }: { title: string; href: string; desc: string; emoji: string }) => (
-    <a
+    <Link
       href={href}
       className="group rounded-2xl border bg-white p-5 shadow-sm hover:shadow transition flex flex-col"
     >
@@ -68,7 +69,7 @@ export default function Home() {
       <div className="mt-3 text-indigo-600 text-sm opacity-0 group-hover:opacity-100">
         Apri →
       </div>
-    </a>
+    </Link>
   );
 
   const Kpi = ({ label, value }: { label: string; value: string | number }) => (

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export default function Header() {
   return (
     <header className="border-b bg-white sticky top-0 z-10">
@@ -6,11 +8,11 @@ export default function Header() {
           My Tunnel Wait
         </h1>
         <nav className="text-sm text-gray-600 flex gap-3">
-          <a href="/" className="hover:underline">Home</a>
-          <a href="/log" className="hover:underline">Log</a>
-          <a href="/chart" className="hover:underline">Grafico</a>
-          <a href="/plan" className="hover:underline">Plan</a>
-          <a href="/history" className="hover:underline">Storico</a>
+          <Link href="/" className="hover:underline">Home</Link>
+          <Link href="/log" className="hover:underline">Log</Link>
+          <Link href="/chart" className="hover:underline">Grafico</Link>
+          <Link href="/plan" className="hover:underline">Plan</Link>
+          <Link href="/history" className="hover:underline">Storico</Link>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- Replace raw anchor tags with Next.js `Link` in the header and home page cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Error: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68affe96e5748330af94b451a6785052