### PR TITLE
fix: invoke supabase admin client

### DIFF
--- a/app/api/heatmap/route.ts
+++ b/app/api/heatmap/route.ts
@@ -10,7 +10,8 @@ function empty(): number[][] {
 function pgDowToMonFirst(pgDow: number) { return pgDow === 0 ? 6 : pgDow - 1; }
 
 export async function GET() {
-  const { data, error } = await supabaseAdmin
+  const supabase = supabaseAdmin();
+  const { data, error } = await supabase
     .from("mv_traffic_heatmap_weekly")
     .select("dow,hour,category,events");
 

--- a/app/heatmap/page.tsx
+++ b/app/heatmap/page.tsx
@@ -24,7 +24,8 @@ function pgDowToMonFirst(pgDow: number): number {
 
 export default async function Page() {
   // Legge tutta la MV (poche righe: 7*24*2)
-  const { data, error } = await supabaseAdmin
+  const supabase = supabaseAdmin();
+  const { data, error } = await supabase
     .from("mv_traffic_heatmap_weekly")
     .select("dow,hour,category,events");
 


### PR DESCRIPTION
## Summary
- call `supabaseAdmin()` to obtain client before using `.from`/`.rpc`
- reuse Supabase client for chunked upserts and heatmap queries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b1800e1b6c8330af6885e0d452dd52