### PR TITLE
feat: store manual measurements on supabase

### DIFF
--- a/app/api/cron/gotthard/route.ts
+++ b/app/api/cron/gotthard/route.ts
@@ -27,7 +27,7 @@ function toRecord(s: SituationLite) {
 
 // upsert in chunk per non superare limiti payload
 async function upsertSituations(recs: ReturnType<typeof toRecord>[]) {
-  const supabase = supabaseAdmin();
+  const supabase = supabaseAdmin;
   const CHUNK = 500;
   let saved = 0;
   for (let i = 0; i < recs.length; i += CHUNK) {
@@ -44,7 +44,7 @@ async function upsertSituations(recs: ReturnType<typeof toRecord>[]) {
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
-  const supabase = supabaseAdmin();
+  const supabase = supabaseAdmin;
 
   try {
     // protezione cron

--- a/app/api/heatmap/route.ts
+++ b/app/api/heatmap/route.ts
@@ -10,7 +10,7 @@ function empty(): number[][] {
 function pgDowToMonFirst(pgDow: number) { return pgDow === 0 ? 6 : pgDow - 1; }
 
 export async function GET() {
-  const supabase = supabaseAdmin();
+  const supabase = supabaseAdmin;
   const { data, error } = await supabase
     .from("mv_traffic_heatmap_weekly")
     .select("dow,hour,category,events");

--- a/app/heatmap/page.tsx
+++ b/app/heatmap/page.tsx
@@ -24,7 +24,7 @@ function pgDowToMonFirst(pgDow: number): number {
 
 export default async function Page() {
   // Legge tutta la MV (poche righe: 7*24*2)
-  const supabase = supabaseAdmin();
+  const supabase = supabaseAdmin;
   const { data, error } = await supabase
     .from("mv_traffic_heatmap_weekly")
     .select("dow,hour,category,events");

--- a/app/history/data.ts
+++ b/app/history/data.ts
@@ -45,7 +45,7 @@ export async function getHistoryRowsSince(
   opts?: { onlySource?: string; dir?: 'N2S' | 'S2N' | 'BOTH' }
 ): Promise<Row[]> {
   const sinceIso = new Date(Date.now() - hours * 3600_000).toISOString();
-  const sb = supabaseAdmin();
+  const sb = supabaseAdmin;
 
   let q = sb
     .from('wait_observations')
@@ -71,7 +71,7 @@ export async function getLatest(
   limit = 50,
   onlySource?: string
 ): Promise<Row[]> {
-  const sb = supabaseAdmin();
+  const sb = supabaseAdmin;
 
   let q = sb
     .from('wait_observations')

--- a/lib/submitManualMeasurement.ts
+++ b/lib/submitManualMeasurement.ts
@@ -1,0 +1,23 @@
+export type ManualMeasurementInput = {
+  tunnel: "gotthard" | "monte_bianco";
+  direction: "northbound" | "southbound";
+  wait_minutes: number;
+  lanes_open?: number;
+  note?: string;
+  observed_at?: string; // new Date().toISOString()
+  lat?: number;
+  lon?: number;
+};
+
+export async function submitManualMeasurement(input: ManualMeasurementInput) {
+  const res = await fetch("/api/measurements", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err?.error || "Submit failed");
+  }
+  return (await res.json()) as { ok: true; id: string; observed_at: string };
+}

--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,24 +1,8 @@
 // Server-only Supabase admin client (service role)
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from "@supabase/supabase-js";
 
-let _client: SupabaseClient | null = null;
-
-export function supabaseAdmin(): SupabaseClient {
-  if (typeof window !== 'undefined') {
-    throw new Error('supabaseAdmin() deve essere usato solo lato server.');
-  }
-  if (_client) return _client;
-
-  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-  if (!url) throw new Error('Manca SUPABASE_URL (o NEXT_PUBLIC_SUPABASE_URL).');
-  if (!serviceKey) throw new Error('Manca SUPABASE_SERVICE_ROLE_KEY (service role).');
-
-  _client = createClient(url, serviceKey, {
-    auth: { persistSession: false, autoRefreshToken: false },
-    db: { schema: 'public' },
-  });
-
-  return _client;
-}
+export const supabaseAdmin = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!, // solo server!
+  { auth: { persistSession: false } }
+);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "recharts": "^3.1.2",
-    "xml2js": "^0.6.2"
+    "xml2js": "^0.6.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "24.3.0",

--- a/supabase/migrations/01_manual_measurements.sql
+++ b/supabase/migrations/01_manual_measurements.sql
@@ -1,0 +1,53 @@
+create type tunnel_id as enum ('gotthard', 'monte_bianco');
+create type traffic_direction as enum ('northbound', 'southbound');
+create type measurement_source as enum ('manual', 'sensor', 'api');
+
+create table if not exists public.manual_measurements (
+  id                uuid primary key default gen_random_uuid(),
+  created_at        timestamptz not null default now(),
+  observed_at       timestamptz not null default now(),
+
+  tunnel            tunnel_id not null,
+  direction         traffic_direction not null,
+
+  wait_minutes      integer not null check (wait_minutes >= 0 and wait_minutes <= 720),
+  lanes_open        smallint check (lanes_open >= 0 and lanes_open <= 8),
+
+  note              text,
+  lat               double precision,
+  lon               double precision,
+
+  -- opzionale: collega l’utente se autenticato
+  reporter_id       uuid references auth.users(id) on delete set null,
+
+  -- tracciabilità di base
+  client_ip         inet,
+  user_agent        text,
+
+  source            measurement_source not null default 'manual'
+);
+
+comment on table public.manual_measurements is 'Manual tunnel wait measurements submitted by users';
+comment on column public.manual_measurements.observed_at is 'Time the queue was observed (not just when submitted)';
+
+-- Indici utili
+create index if not exists idx_manual_measurements_tunnel_obs
+  on public.manual_measurements (tunnel, observed_at desc);
+create index if not exists idx_manual_measurements_dir_obs
+  on public.manual_measurements (direction, observed_at desc);
+
+-- Abilita RLS
+alter table public.manual_measurements enable row level security;
+
+-- POLITICHE:
+-- 1) Lettura pubblica (se vuoi far vedere subito i dati aggregati/cronologia)
+create policy "Public can read manual measurements"
+  on public.manual_measurements for select
+  using (true);
+
+-- 2) Inserimento: SOLO tramite il backend (service role) -> nessuna policy insert per i client
+--    (così non esponi l'anon key a scritture dirette)
+--    Se un domani vuoi permettere insert da utenti loggati direttamente dal client:
+--    create policy "Authenticated can insert their own measurements"
+--      on public.manual_measurements for insert
+--      with check (auth.uid() = reporter_id);


### PR DESCRIPTION
## Summary
- add SQL migration and RLS policies for manual_measurements table
- expose supabaseAdmin client constant and update usage
- add client helper to submit manual measurement via /api/measurements

## Testing
- `npm test` *(fails: Missing script "test")*
- `NEXT_PUBLIC_SUPABASE_URL="https://example.com" SUPABASE_SERVICE_ROLE_KEY="test" npm run build` *(fails: Module not found: Can't resolve 'zod')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/zod)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a69903408330ab0fddab20a5a7dc