### PR TITLE
chore: remove unused expect-error

### DIFF
--- a/app/api/measurements/route.ts
+++ b/app/api/measurements/route.ts
@@ -20,7 +20,6 @@ export async function POST(req: NextRequest) {
     const ua = req.headers.get("user-agent") ?? undefined;
     const ip =
       req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-      // @ts-expect-error: next/internal
       (req as any).ip ||
       undefined;
 


### PR DESCRIPTION
## Summary
- remove unused ts-expect-error in measurements API route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Module not found: Can't resolve 'zod')*

------
https://chatgpt.com/codex/tasks/task_e_68b1aa27326c83308f66f668771f9223