### PR TITLE
Fix manual measurement insertion

### DIFF
--- a/app/api/measurements/route.ts
+++ b/app/api/measurements/route.ts
@@ -71,26 +71,27 @@ export async function POST(req: NextRequest) {
 
     const b = json;
 
+    // Converti la direzione nel formato atteso dal database
+    const dir = b.direction === "northbound" ? "S2N" : "N2S";
+
     // Se usi Supabase Auth lato app, puoi recuperare user id dai cookies session (opzionale)
     // In questo esempio lasciamo reporter_id null
     const { error, data } = await supabaseAdmin()
       .from("manual_measurements")
-      .insert([
-        {
-          tunnel: b.tunnel,
-          direction: b.direction,
-          wait_minutes: b.wait_minutes,
-          lanes_open: b.lanes_open ?? null,
-          note: b.note ?? null,
-          observed_at: b.observed_at ?? new Date().toISOString(),
-          lat: b.lat ?? null,
-          lon: b.lon ?? null,
-          reporter_id: null,
-          client_ip: ip ?? null,
-          user_agent: ua ?? null,
-          source: "manual",
-        },
-      ])
+      .insert({
+        tunnel: b.tunnel,
+        dir,
+        wait_min: b.wait_minutes,
+        lanes_open: b.lanes_open ?? null,
+        note: b.note ?? null,
+        observed_at: b.observed_at ?? new Date().toISOString(),
+        lat: b.lat ?? null,
+        lon: b.lon ?? null,
+        reporter_id: null,
+        client_ip: ip ?? null,
+        user_agent: ua ?? null,
+        source: "manual",
+      })
       .select("id, observed_at")
       .single();
 


### PR DESCRIPTION
## Summary
- Map incoming direction to database format and use correct column names when inserting manual measurements

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: supabaseUrl is required)


------
https://chatgpt.com/codex/tasks/task_e_68b2c1f38c088330af11244caff7ad27