### PR TITLE
Use REST API for manual measurements

### DIFF
--- a/lib/supabaseAdmin.ts
+++ b/lib/supabaseAdmin.ts
@@ -1,20 +1,13 @@
 // lib/supabaseAdmin.ts
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 
-let _client: SupabaseClient | null = null;
+let client: SupabaseClient | null = null;
 
 export function supabaseAdmin(): SupabaseClient {
-  if (typeof window !== "undefined") {
-    throw new Error("supabaseAdmin() deve essere usato solo lato server.");
-  }
-  if (_client) return _client;
-
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-  if (!url) throw new Error("Manca NEXT_PUBLIC_SUPABASE_URL.");
-  if (!serviceKey) throw new Error("Manca SUPABASE_SERVICE_ROLE_KEY (service role).");
-
-  _client = createClient(url, serviceKey, { auth: { persistSession: false } });
-  return _client;
+  if (typeof window !== "undefined") throw new Error("server-only");
+  if (client) return client;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  client = createClient(url, key, { auth: { persistSession: false } });
+  return client;
 }


### PR DESCRIPTION
## Summary
- switch manual measurement insert to Supabase REST API
- simplify Supabase admin client singleton

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fae81fcc8330a9dc159645a4f091